### PR TITLE
Here's the plan to add an option to skip closing game clients before …

### DIFF
--- a/UnoraLaunchpad/MainWindow.xaml.cs
+++ b/UnoraLaunchpad/MainWindow.xaml.cs
@@ -279,6 +279,16 @@ namespace UnoraLaunchpad
             }
             var lockWindow = new UpdateLockWindow();
             var result = lockWindow.ShowDialog();
+
+            if (lockWindow.UserSkippedClosingClients) // Added this block
+            {
+                MessageBox.Show(
+                    "You've chosen to skip closing active game clients. Game files may not update correctly, and you might encounter incorrect assets in-game until all clients are closed and the launcher performs a full update check.",
+                    "Update Warning",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Warning);
+            }
+
             return result == true;
         }
 

--- a/UnoraLaunchpad/UpdateLockWIndow.xaml
+++ b/UnoraLaunchpad/UpdateLockWIndow.xaml
@@ -8,12 +8,16 @@
     <Border CornerRadius="18" Background="{DynamicResource SecondaryBackgroundColor}" Padding="24">
         <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
             <TextBlock Text="Updater Client Check" FontSize="22" FontWeight="Bold" Foreground="{DynamicResource AccentColor1}" Margin="0,0,0,8" HorizontalAlignment="Center"/>
-            <TextBlock Name="StatusText" Text="Please close all Darkages windows before updating."
+            <TextBlock Name="StatusText" Text="Checking for active game clients..."
                        FontSize="16" Foreground="{DynamicResource PrimaryTextColor}" TextAlignment="Center" Margin="0,0,0,10"/>
             <Button Content="Check Again" Name="CheckAgainBtn" Height="36" Width="148" Margin="0,12,0,0"
                     FontWeight="Bold" Click="CheckAgainBtn_Click"
                     Background="{DynamicResource AccentColor1}"
                     Foreground="{DynamicResource PrimaryBackgroundColor}"/>
+            <Button Content="Skip and Continue" Name="SkipBtn" Height="32" Width="148" Margin="0,10,0,0"
+                    Click="SkipBtn_Click"
+                    Background="{DynamicResource TertiaryBackgroundColor}"
+                    Foreground="{DynamicResource AccentColor1}"/>
             <Button Content="Cancel Update" Name="CancelBtn" Height="32" Width="148" Margin="0,10,0,0"
                     Click="CancelBtn_Click"
                     Background="{DynamicResource TertiaryBackgroundColor}"

--- a/UnoraLaunchpad/UpdateLockWIndow.xaml.cs
+++ b/UnoraLaunchpad/UpdateLockWIndow.xaml.cs
@@ -9,6 +9,7 @@ namespace UnoraLaunchpad
 {
     public partial class UpdateLockWindow : Window
     {
+        public bool UserSkippedClosingClients { get; private set; } = false;
         private static readonly Dictionary<string, string> ThemeResourceMap = new()
         {
             { "Dark", "pack://application:,,,/Resources/DarkTheme.xaml" },
@@ -63,7 +64,7 @@ namespace UnoraLaunchpad
             }
             else
             {
-                StatusText.Text = $"Close {procs.Length} instance(s) of Unora to proceed.";
+                StatusText.Text = $"Found {procs.Length} game client(s) running. It's recommended to close them before updating, or you can choose to skip and continue (this may cause issues).";
             }
         }
 
@@ -76,6 +77,13 @@ namespace UnoraLaunchpad
 
             // Immediately close the entire launcher app
             Application.Current.Shutdown();
+        }
+
+        private void SkipBtn_Click(object sender, RoutedEventArgs e)
+        {
+            UserSkippedClosingClients = true;
+            DialogResult = true;
+            Close();
         }
     }
 }


### PR DESCRIPTION
…an update:

This feature will introduce a 'Skip and Continue' button on the UpdateLockWindow. This will allow you to proceed with game updates without closing active game clients.

Here's what I'll do:
- Add a 'Skip and Continue' button to UpdateLockWindow.xaml.
- Implement a `UserSkippedClosingClients` property and the necessary logic for the button click in UpdateLockWindow.xaml.cs.
- Modify MainWindow.xaml.cs to check if you skipped closing clients and, if so, display a warning message about potential issues with file updates and in-game assets.
- Update the text in UpdateLockWindow to inform you of this new option and still recommend closing clients for the best experience.