### PR TITLE
feat: Enhance saved client launching and password security

### DIFF
--- a/UnoraLaunchpad/Character.cs
+++ b/UnoraLaunchpad/Character.cs
@@ -1,8 +1,13 @@
-﻿namespace UnoraLaunchpad
+﻿using Newtonsoft.Json;
+
+namespace UnoraLaunchpad
 {
     public class Character
     {
         public string Username { get; set; }
+        [JsonIgnore]
         public string Password { get; set; }
+        public string PasswordHash { get; set; }
+        public string Salt { get; set; }
     }
 }

--- a/UnoraLaunchpad/MainWindow.xaml
+++ b/UnoraLaunchpad/MainWindow.xaml
@@ -208,21 +208,26 @@
                    Margin="0,8,0,0"/>
     </Grid>
 
-    <!-- New "Launch Saved Clients" Button -->
-    <Button x:Name="LaunchSavedBtn"
-            Click="LaunchSavedBtn_Click"
-            Height="30"
-            Padding="10,0"
-            materialDesign:ButtonAssist.CornerRadius="5"
-            HorizontalAlignment="Right"
-            VerticalAlignment="Center"
-            Foreground="{DynamicResource ButtonForegroundColor}"
-            Background="{DynamicResource ButtonBackgroundColor}"
-            Margin="0,0,110,0"
-            Style="{StaticResource MaterialDesignRaisedLightButton}"
-            ToolTip="Launch a client saved in Settings.">
-        <TextBlock Text="Launch Saved" />
-    </Button>
+    <!-- StackPanel for ComboBox and LaunchSavedBtn -->
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,110,0">
+        <ComboBox x:Name="SavedCharactersComboBox"
+                  Width="120"
+                  Height="30"
+                  VerticalContentAlignment="Center"
+                  Margin="0,0,5,0"
+                  ToolTip="Select a saved character or 'All'" />
+        <Button x:Name="LaunchSavedBtn"
+                Click="LaunchSavedBtn_Click"
+                Height="30"
+                Padding="10,0"
+                materialDesign:ButtonAssist.CornerRadius="5"
+                Foreground="{DynamicResource ButtonForegroundColor}"
+                Background="{DynamicResource ButtonBackgroundColor}"
+                Style="{StaticResource MaterialDesignRaisedLightButton}"
+                ToolTip="Launch the selected saved client(s).">
+            <TextBlock Text="Launch Saved" />
+        </Button>
+    </StackPanel>
 
     <!-- Existing Launch Button -->
     <Button x:Name="LaunchBtn"

--- a/UnoraLaunchpad/PasswordHelper.cs
+++ b/UnoraLaunchpad/PasswordHelper.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Security.Cryptography;
+using System.Text; // For Encoding if needed, though not directly for Rfc2898DeriveBytes password string
+
+namespace UnoraLaunchpad
+{
+    public static class PasswordHelper
+    {
+        private const int SaltSize = 16; // bytes
+        private const int HashSize = 32; // bytes
+        private const int Iterations = 10000;
+
+        public static string GenerateSalt()
+        {
+            byte[] salt = new byte[SaltSize];
+            using (var rng = RandomNumberGenerator.Create())
+            {
+                rng.GetBytes(salt);
+            }
+            return Convert.ToBase64String(salt);
+        }
+
+        public static string HashPassword(string password, string saltString)
+        {
+            byte[] salt = Convert.FromBase64String(saltString);
+            // Password string to bytes conversion: UTF-8 is standard.
+            byte[] passwordBytes = Encoding.UTF8.GetBytes(password);
+
+            using (var pbkdf2 = new Rfc2898DeriveBytes(passwordBytes, salt, Iterations))
+            {
+                byte[] hash = pbkdf2.GetBytes(HashSize);
+                return Convert.ToBase64String(hash);
+            }
+        }
+
+        public static bool VerifyPassword(string password, string storedHashString, string saltString)
+        {
+            byte[] salt = Convert.FromBase64String(saltString);
+            byte[] storedHash = Convert.FromBase64String(storedHashString);
+            byte[] passwordBytes = Encoding.UTF8.GetBytes(password);
+
+            using (var pbkdf2 = new Rfc2898DeriveBytes(passwordBytes, salt, Iterations))
+            {
+                byte[] testHash = pbkdf2.GetBytes(HashSize);
+                // Simple byte-by-byte comparison
+                if (testHash.Length != storedHash.Length) return false;
+                for (int i = 0; i < testHash.Length; i++)
+                {
+                    if (testHash[i] != storedHash[i]) return false;
+                }
+                return true;
+            }
+        }
+    }
+}

--- a/UnoraLaunchpad/PasswordPromptDialog.xaml
+++ b/UnoraLaunchpad/PasswordPromptDialog.xaml
@@ -1,0 +1,28 @@
+<Window x:Class="UnoraLaunchpad.PasswordPromptDialog"
+           xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+           xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+           xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+           xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+           mc:Ignorable="d"
+           Title="Enter Password"
+           SizeToContent="WidthAndHeight"
+           WindowStartupLocation="CenterOwner"
+           WindowStyle="ToolWindow"
+           ResizeMode="NoResize"
+           Width="300">
+       <Grid Margin="15">
+           <Grid.RowDefinitions>
+               <RowDefinition Height="Auto"/>
+               <RowDefinition Height="Auto"/>
+               <RowDefinition Height="Auto"/>
+           </Grid.RowDefinitions>
+
+           <TextBlock x:Name="PromptText" Grid.Row="0" Margin="0,0,0,10" TextWrapping="Wrap" Text="Enter password for:"/>
+           <PasswordBox x:Name="PasswordInputBox" Grid.Row="1" MinWidth="250" Margin="0,0,0,15"/>
+
+           <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
+               <Button x:Name="OkButton" Content="OK" Width="75" Margin="0,0,10,0" IsDefault="True" Click="OkButton_Click"/>
+               <Button x:Name="CancelButton" Content="Cancel" Width="75" IsCancel="True" Click="CancelButton_Click"/>
+           </StackPanel>
+       </Grid>
+   </Window>

--- a/UnoraLaunchpad/PasswordPromptDialog.xaml.cs
+++ b/UnoraLaunchpad/PasswordPromptDialog.xaml.cs
@@ -1,0 +1,30 @@
+using System.Windows;
+
+namespace UnoraLaunchpad
+{
+    public partial class PasswordPromptDialog : Window
+    {
+        public string Password { get; private set; }
+
+        public PasswordPromptDialog(string username)
+        {
+            InitializeComponent();
+            Title = $"Password for {username}";
+            PromptText.Text = $"Enter password for \"{username}\":"; // Corrected string interpolation
+            PasswordInputBox.Focus();
+        }
+
+        private void OkButton_Click(object sender, RoutedEventArgs e)
+        {
+            Password = PasswordInputBox.Password;
+            DialogResult = true;
+            Close();
+        }
+
+        private void CancelButton_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces several enhancements to the saved client launching functionality and improves password security.

Key changes:
- Implemented password hashing (PBKDF2 with salt) for saved character credentials. Passwords are no longer stored in plaintext in the settings file.
- Added a one-time migration process for existing plaintext passwords to the new hashed format upon application startup.
- Introduced a dropdown menu next to the "Launch Saved" button, allowing you to select either "All" saved characters or a specific character by username.
- Modified the "Launch Saved" button functionality to act on the selection in the new dropdown.
- Implemented a password prompt dialog that appears when launching a saved character. You must enter the password for the current session, which is then used by the automated login mechanism. This plaintext password is not stored.
- Updated the settings window to correctly save new or edited character passwords in the hashed format.
- Added `PasswordHelper` class for hashing and salt generation logic.
- Created `PasswordPromptDialog` for runtime password input.

These changes provide you with more flexible ways to launch your saved game clients while significantly improving the security of stored credentials.