### PR TITLE
fix: Add missing files to UnoraLaunchpad.csproj

### DIFF
--- a/UnoraLaunchpad/UnoraLaunchpad.csproj
+++ b/UnoraLaunchpad/UnoraLaunchpad.csproj
@@ -77,6 +77,7 @@
     <Compile Include="GameUpdateDetailView.xaml.cs">
       <DependentUpon>GameUpdateDetailView.xaml</DependentUpon>
     </Compile>
+    <Compile Include="PasswordHelper.cs" />
     <Compile Include="UnoraClient.cs" />
     <Compile Include="Launcher\ClientVersion.cs" />
     <Compile Include="Launcher\Flags.cs" />
@@ -109,7 +110,14 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="PasswordPromptDialog.xaml.cs">
+      <DependentUpon>PasswordPromptDialog.xaml</DependentUpon>
+    </Compile>
     <Page Include="PatchNotesWindow.xaml" />
+    <Page Include="PasswordPromptDialog.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Resources\AmberTheme.xaml" />
     <Page Include="Resources\DarkTheme.xaml" />
     <Page Include="Resources\EmeraldTheme.xaml" />


### PR DESCRIPTION
The following newly added files were missing from the project file:
- PasswordHelper.cs
- PasswordPromptDialog.xaml
- PasswordPromptDialog.xaml.cs

This commit updates UnoraLaunchpad.csproj to include these files, ensuring they are correctly compiled and included in the build. This resolves an oversight from the previous feature commit.