### PR TITLE
Add 10 new color themes and integrate them into the application

### DIFF
--- a/UnoraLaunchpad/App.xaml.cs
+++ b/UnoraLaunchpad/App.xaml.cs
@@ -63,6 +63,16 @@ namespace UnoraLaunchpad
                 "Violet"  => "VioletTheme.xaml",
                 "Amber"   => "AmberTheme.xaml",
                 "Emerald" => "EmeraldTheme.xaml",
+                "Ruby"    => "RubyTheme.xaml",
+                "Sapphire" => "SapphireTheme.xaml",
+                "Topaz"   => "TopazTheme.xaml",
+                "Amethyst" => "AmethystTheme.xaml",
+                "Garnet"  => "GarnetTheme.xaml",
+                "Pearl"   => "PearlTheme.xaml",
+                "Obsidian" => "ObsidianTheme.xaml",
+                "Citrine" => "CitrineTheme.xaml",
+                "Peridot" => "PeridotTheme.xaml",
+                "Aquamarine" => "AquamarineTheme.xaml",
                 _         => "DarkTheme.xaml"
             };
 

--- a/UnoraLaunchpad/MainWindow.xaml.cs
+++ b/UnoraLaunchpad/MainWindow.xaml.cs
@@ -136,6 +136,36 @@ namespace UnoraLaunchpad
                 case "Emerald":
                     themeUri = new Uri("pack://application:,,,/Resources/EmeraldTheme.xaml", UriKind.Absolute);
                     break;
+                case "Ruby":
+                    themeUri = new Uri("pack://application:,,,/Resources/RubyTheme.xaml", UriKind.Absolute);
+                    break;
+                case "Sapphire":
+                    themeUri = new Uri("pack://application:,,,/Resources/SapphireTheme.xaml", UriKind.Absolute);
+                    break;
+                case "Topaz":
+                    themeUri = new Uri("pack://application:,,,/Resources/TopazTheme.xaml", UriKind.Absolute);
+                    break;
+                case "Amethyst":
+                    themeUri = new Uri("pack://application:,,,/Resources/AmethystTheme.xaml", UriKind.Absolute);
+                    break;
+                case "Garnet":
+                    themeUri = new Uri("pack://application:,,,/Resources/GarnetTheme.xaml", UriKind.Absolute);
+                    break;
+                case "Pearl":
+                    themeUri = new Uri("pack://application:,,,/Resources/PearlTheme.xaml", UriKind.Absolute);
+                    break;
+                case "Obsidian":
+                    themeUri = new Uri("pack://application:,,,/Resources/ObsidianTheme.xaml", UriKind.Absolute);
+                    break;
+                case "Citrine":
+                    themeUri = new Uri("pack://application:,,,/Resources/CitrineTheme.xaml", UriKind.Absolute);
+                    break;
+                case "Peridot":
+                    themeUri = new Uri("pack://application:,,,/Resources/PeridotTheme.xaml", UriKind.Absolute);
+                    break;
+                case "Aquamarine":
+                    themeUri = new Uri("pack://application:,,,/Resources/AquamarineTheme.xaml", UriKind.Absolute);
+                    break;
                 default:
                     themeUri = new Uri("pack://application:,,,/Resources/DarkTheme.xaml", UriKind.Absolute);
                     break;

--- a/UnoraLaunchpad/Resources/AmethystTheme.xaml
+++ b/UnoraLaunchpad/Resources/AmethystTheme.xaml
@@ -1,0 +1,44 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Background Colors -->
+    <SolidColorBrush x:Key="PrimaryBackgroundColor" Color="#2E004B"/>
+    <SolidColorBrush x:Key="SecondaryBackgroundColor" Color="#480072"/>
+    <SolidColorBrush x:Key="TertiaryBackgroundColor" Color="#600099"/>
+
+    <!-- Title Bar Colors -->
+    <SolidColorBrush x:Key="TitleBarColor" Color="#7D00CC"/>
+    <SolidColorBrush x:Key="TitleBarTextColor" Color="#F0D1FF"/>
+
+    <!-- Text Colors -->
+    <SolidColorBrush x:Key="PrimaryTextColor" Color="#F0D1FF"/>
+    <SolidColorBrush x:Key="SecondaryTextColor" Color="#E0B3FF"/>
+    <SolidColorBrush x:Key="IconForegroundColor" Color="#E0B3FF"/>
+
+    <!-- Button Colors -->
+    <SolidColorBrush x:Key="ButtonBackgroundColor" Color="#7D00CC"/>
+    <SolidColorBrush x:Key="ButtonForegroundColor" Color="#F0D1FF"/>
+    <SolidColorBrush x:Key="ButtonTransparentBackgroundColor" Color="Transparent"/>
+
+    <!-- Border Colors -->
+    <SolidColorBrush x:Key="PrimaryBorderColor" Color="#E0B3FF"/>
+    <SolidColorBrush x:Key="SecondaryBorderColor" Color="#7D00CC"/>
+
+    <!-- Accent Colors -->
+    <SolidColorBrush x:Key="AccentColor1" Color="#9900FF"/> <!-- Bright Purple -->
+    <SolidColorBrush x:Key="AccentColor2" Color="#8A00E6"/>
+
+    <!-- Game Update Tile Specific -->
+    <SolidColorBrush x:Key="GameTileBackgroundColor" Color="#480072"/>
+    <SolidColorBrush x:Key="GameTileBorderColor" Color="#E0B3FF"/>
+    <SolidColorBrush x:Key="GameTileTextColor" Color="#F0D1FF"/>
+    <SolidColorBrush x:Key="GameTileDescriptionBackgroundColor" Color="#992E004B"/>
+
+    <!-- MaterialDesign Checkbox Colors -->
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxOff" Color="#E0B3FF"/>
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxChecked" Color="#9900FF"/>
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxDisabled" Color="#7D00CC"/>
+    <SolidColorBrush x:Key="MaterialDesignBody" Color="#F0D1FF"/>
+    <SolidColorBrush x:Key="MaterialDesignBodyLight" Color="#E0B3FF"/>
+    <SolidColorBrush x:Key="MaterialDesignPaper" Color="#480072"/>
+</ResourceDictionary>

--- a/UnoraLaunchpad/Resources/AquamarineTheme.xaml
+++ b/UnoraLaunchpad/Resources/AquamarineTheme.xaml
@@ -1,0 +1,44 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Background Colors -->
+    <SolidColorBrush x:Key="PrimaryBackgroundColor" Color="#003B34"/>
+    <SolidColorBrush x:Key="SecondaryBackgroundColor" Color="#005C50"/>
+    <SolidColorBrush x:Key="TertiaryBackgroundColor" Color="#007C6B"/>
+
+    <!-- Title Bar Colors -->
+    <SolidColorBrush x:Key="TitleBarColor" Color="#00A88F"/>
+    <SolidColorBrush x:Key="TitleBarTextColor" Color="#D1FFF7"/>
+
+    <!-- Text Colors -->
+    <SolidColorBrush x:Key="PrimaryTextColor" Color="#D1FFF7"/>
+    <SolidColorBrush x:Key="SecondaryTextColor" Color="#B3FFEF"/>
+    <SolidColorBrush x:Key="IconForegroundColor" Color="#B3FFEF"/>
+
+    <!-- Button Colors -->
+    <SolidColorBrush x:Key="ButtonBackgroundColor" Color="#00A88F"/>
+    <SolidColorBrush x:Key="ButtonForegroundColor" Color="#D1FFF7"/>
+    <SolidColorBrush x:Key="ButtonTransparentBackgroundColor" Color="Transparent"/>
+
+    <!-- Border Colors -->
+    <SolidColorBrush x:Key="PrimaryBorderColor" Color="#B3FFEF"/>
+    <SolidColorBrush x:Key="SecondaryBorderColor" Color="#00A88F"/>
+
+    <!-- Accent Colors -->
+    <SolidColorBrush x:Key="AccentColor1" Color="#00FFCC"/> <!-- Bright Teal -->
+    <SolidColorBrush x:Key="AccentColor2" Color="#00E6B8"/>
+
+    <!-- Game Update Tile Specific -->
+    <SolidColorBrush x:Key="GameTileBackgroundColor" Color="#005C50"/>
+    <SolidColorBrush x:Key="GameTileBorderColor" Color="#B3FFEF"/>
+    <SolidColorBrush x:Key="GameTileTextColor" Color="#D1FFF7"/>
+    <SolidColorBrush x:Key="GameTileDescriptionBackgroundColor" Color="#99003B34"/>
+
+    <!-- MaterialDesign Checkbox Colors -->
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxOff" Color="#B3FFEF"/>
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxChecked" Color="#00FFCC"/>
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxDisabled" Color="#00A88F"/>
+    <SolidColorBrush x:Key="MaterialDesignBody" Color="#D1FFF7"/>
+    <SolidColorBrush x:Key="MaterialDesignBodyLight" Color="#B3FFEF"/>
+    <SolidColorBrush x:Key="MaterialDesignPaper" Color="#005C50"/>
+</ResourceDictionary>

--- a/UnoraLaunchpad/Resources/CitrineTheme.xaml
+++ b/UnoraLaunchpad/Resources/CitrineTheme.xaml
@@ -1,0 +1,44 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Background Colors -->
+    <SolidColorBrush x:Key="PrimaryBackgroundColor" Color="#4D2200"/>
+    <SolidColorBrush x:Key="SecondaryBackgroundColor" Color="#663300"/>
+    <SolidColorBrush x:Key="TertiaryBackgroundColor" Color="#804400"/>
+
+    <!-- Title Bar Colors -->
+    <SolidColorBrush x:Key="TitleBarColor" Color="#B36600"/>
+    <SolidColorBrush x:Key="TitleBarTextColor" Color="#FFE8D1"/>
+
+    <!-- Text Colors -->
+    <SolidColorBrush x:Key="PrimaryTextColor" Color="#FFE8D1"/>
+    <SolidColorBrush x:Key="SecondaryTextColor" Color="#FFDAB3"/>
+    <SolidColorBrush x:Key="IconForegroundColor" Color="#FFDAB3"/>
+
+    <!-- Button Colors -->
+    <SolidColorBrush x:Key="ButtonBackgroundColor" Color="#B36600"/>
+    <SolidColorBrush x:Key="ButtonForegroundColor" Color="#FFE8D1"/>
+    <SolidColorBrush x:Key="ButtonTransparentBackgroundColor" Color="Transparent"/>
+
+    <!-- Border Colors -->
+    <SolidColorBrush x:Key="PrimaryBorderColor" Color="#FFDAB3"/>
+    <SolidColorBrush x:Key="SecondaryBorderColor" Color="#B36600"/>
+
+    <!-- Accent Colors -->
+    <SolidColorBrush x:Key="AccentColor1" Color="#FF8800"/> <!-- Bright Orange -->
+    <SolidColorBrush x:Key="AccentColor2" Color="#E67700"/>
+
+    <!-- Game Update Tile Specific -->
+    <SolidColorBrush x:Key="GameTileBackgroundColor" Color="#663300"/>
+    <SolidColorBrush x:Key="GameTileBorderColor" Color="#FFDAB3"/>
+    <SolidColorBrush x:Key="GameTileTextColor" Color="#FFE8D1"/>
+    <SolidColorBrush x:Key="GameTileDescriptionBackgroundColor" Color="#994D2200"/>
+
+    <!-- MaterialDesign Checkbox Colors -->
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxOff" Color="#FFDAB3"/>
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxChecked" Color="#FF8800"/>
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxDisabled" Color="#B36600"/>
+    <SolidColorBrush x:Key="MaterialDesignBody" Color="#FFE8D1"/>
+    <SolidColorBrush x:Key="MaterialDesignBodyLight" Color="#FFDAB3"/>
+    <SolidColorBrush x:Key="MaterialDesignPaper" Color="#663300"/>
+</ResourceDictionary>

--- a/UnoraLaunchpad/Resources/GarnetTheme.xaml
+++ b/UnoraLaunchpad/Resources/GarnetTheme.xaml
@@ -1,0 +1,44 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Background Colors -->
+    <SolidColorBrush x:Key="PrimaryBackgroundColor" Color="#40000D"/>
+    <SolidColorBrush x:Key="SecondaryBackgroundColor" Color="#600014"/>
+    <SolidColorBrush x:Key="TertiaryBackgroundColor" Color="#80001B"/>
+
+    <!-- Title Bar Colors -->
+    <SolidColorBrush x:Key="TitleBarColor" Color="#A00022"/>
+    <SolidColorBrush x:Key="TitleBarTextColor" Color="#FFD1DA"/>
+
+    <!-- Text Colors -->
+    <SolidColorBrush x:Key="PrimaryTextColor" Color="#FFD1DA"/>
+    <SolidColorBrush x:Key="SecondaryTextColor" Color="#FFB3C1"/>
+    <SolidColorBrush x:Key="IconForegroundColor" Color="#FFB3C1"/>
+
+    <!-- Button Colors -->
+    <SolidColorBrush x:Key="ButtonBackgroundColor" Color="#A00022"/>
+    <SolidColorBrush x:Key="ButtonForegroundColor" Color="#FFD1DA"/>
+    <SolidColorBrush x:Key="ButtonTransparentBackgroundColor" Color="Transparent"/>
+
+    <!-- Border Colors -->
+    <SolidColorBrush x:Key="PrimaryBorderColor" Color="#FFB3C1"/>
+    <SolidColorBrush x:Key="SecondaryBorderColor" Color="#A00022"/>
+
+    <!-- Accent Colors -->
+    <SolidColorBrush x:Key="AccentColor1" Color="#C0002B"/> <!-- Deep Red -->
+    <SolidColorBrush x:Key="AccentColor2" Color="#B00026"/>
+
+    <!-- Game Update Tile Specific -->
+    <SolidColorBrush x:Key="GameTileBackgroundColor" Color="#600014"/>
+    <SolidColorBrush x:Key="GameTileBorderColor" Color="#FFB3C1"/>
+    <SolidColorBrush x:Key="GameTileTextColor" Color="#FFD1DA"/>
+    <SolidColorBrush x:Key="GameTileDescriptionBackgroundColor" Color="#9940000D"/>
+
+    <!-- MaterialDesign Checkbox Colors -->
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxOff" Color="#FFB3C1"/>
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxChecked" Color="#C0002B"/>
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxDisabled" Color="#A00022"/>
+    <SolidColorBrush x:Key="MaterialDesignBody" Color="#FFD1DA"/>
+    <SolidColorBrush x:Key="MaterialDesignBodyLight" Color="#FFB3C1"/>
+    <SolidColorBrush x:Key="MaterialDesignPaper" Color="#600014"/>
+</ResourceDictionary>

--- a/UnoraLaunchpad/Resources/ObsidianTheme.xaml
+++ b/UnoraLaunchpad/Resources/ObsidianTheme.xaml
@@ -1,0 +1,44 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Background Colors -->
+    <SolidColorBrush x:Key="PrimaryBackgroundColor" Color="#0A0A0A"/>
+    <SolidColorBrush x:Key="SecondaryBackgroundColor" Color="#141414"/>
+    <SolidColorBrush x:Key="TertiaryBackgroundColor" Color="#1E1E1E"/>
+
+    <!-- Title Bar Colors -->
+    <SolidColorBrush x:Key="TitleBarColor" Color="#282828"/>
+    <SolidColorBrush x:Key="TitleBarTextColor" Color="#E0E0E0"/>
+
+    <!-- Text Colors -->
+    <SolidColorBrush x:Key="PrimaryTextColor" Color="#E0E0E0"/>
+    <SolidColorBrush x:Key="SecondaryTextColor" Color="#C0C0C0"/>
+    <SolidColorBrush x:Key="IconForegroundColor" Color="#C0C0C0"/>
+
+    <!-- Button Colors -->
+    <SolidColorBrush x:Key="ButtonBackgroundColor" Color="#282828"/>
+    <SolidColorBrush x:Key="ButtonForegroundColor" Color="#E0E0E0"/>
+    <SolidColorBrush x:Key="ButtonTransparentBackgroundColor" Color="Transparent"/>
+
+    <!-- Border Colors -->
+    <SolidColorBrush x:Key="PrimaryBorderColor" Color="#C0C0C0"/>
+    <SolidColorBrush x:Key="SecondaryBorderColor" Color="#282828"/>
+
+    <!-- Accent Colors -->
+    <SolidColorBrush x:Key="AccentColor1" Color="#3C3C3C"/> <!-- Dark Gray -->
+    <SolidColorBrush x:Key="AccentColor2" Color="#323232"/>
+
+    <!-- Game Update Tile Specific -->
+    <SolidColorBrush x:Key="GameTileBackgroundColor" Color="#141414"/>
+    <SolidColorBrush x:Key="GameTileBorderColor" Color="#C0C0C0"/>
+    <SolidColorBrush x:Key="GameTileTextColor" Color="#E0E0E0"/>
+    <SolidColorBrush x:Key="GameTileDescriptionBackgroundColor" Color="#990A0A0A"/>
+
+    <!-- MaterialDesign Checkbox Colors -->
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxOff" Color="#C0C0C0"/>
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxChecked" Color="#3C3C3C"/>
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxDisabled" Color="#282828"/>
+    <SolidColorBrush x:Key="MaterialDesignBody" Color="#E0E0E0"/>
+    <SolidColorBrush x:Key="MaterialDesignBodyLight" Color="#C0C0C0"/>
+    <SolidColorBrush x:Key="MaterialDesignPaper" Color="#141414"/>
+</ResourceDictionary>

--- a/UnoraLaunchpad/Resources/PearlTheme.xaml
+++ b/UnoraLaunchpad/Resources/PearlTheme.xaml
@@ -1,0 +1,44 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Background Colors -->
+    <SolidColorBrush x:Key="PrimaryBackgroundColor" Color="#E0E0E0"/>
+    <SolidColorBrush x:Key="SecondaryBackgroundColor" Color="#D0D0D0"/>
+    <SolidColorBrush x:Key="TertiaryBackgroundColor" Color="#C0C0C0"/>
+
+    <!-- Title Bar Colors -->
+    <SolidColorBrush x:Key="TitleBarColor" Color="#B0B0B0"/>
+    <SolidColorBrush x:Key="TitleBarTextColor" Color="#404040"/>
+
+    <!-- Text Colors -->
+    <SolidColorBrush x:Key="PrimaryTextColor" Color="#404040"/>
+    <SolidColorBrush x:Key="SecondaryTextColor" Color="#606060"/>
+    <SolidColorBrush x:Key="IconForegroundColor" Color="#606060"/>
+
+    <!-- Button Colors -->
+    <SolidColorBrush x:Key="ButtonBackgroundColor" Color="#B0B0B0"/>
+    <SolidColorBrush x:Key="ButtonForegroundColor" Color="#404040"/>
+    <SolidColorBrush x:Key="ButtonTransparentBackgroundColor" Color="Transparent"/>
+
+    <!-- Border Colors -->
+    <SolidColorBrush x:Key="PrimaryBorderColor" Color="#606060"/>
+    <SolidColorBrush x:Key="SecondaryBorderColor" Color="#B0B0B0"/>
+
+    <!-- Accent Colors -->
+    <SolidColorBrush x:Key="AccentColor1" Color="#A0A0A0"/> <!-- Light Gray -->
+    <SolidColorBrush x:Key="AccentColor2" Color="#909090"/>
+
+    <!-- Game Update Tile Specific -->
+    <SolidColorBrush x:Key="GameTileBackgroundColor" Color="#D0D0D0"/>
+    <SolidColorBrush x:Key="GameTileBorderColor" Color="#606060"/>
+    <SolidColorBrush x:Key="GameTileTextColor" Color="#404040"/>
+    <SolidColorBrush x:Key="GameTileDescriptionBackgroundColor" Color="#99E0E0E0"/>
+
+    <!-- MaterialDesign Checkbox Colors -->
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxOff" Color="#606060"/>
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxChecked" Color="#A0A0A0"/>
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxDisabled" Color="#B0B0B0"/>
+    <SolidColorBrush x:Key="MaterialDesignBody" Color="#404040"/>
+    <SolidColorBrush x:Key="MaterialDesignBodyLight" Color="#606060"/>
+    <SolidColorBrush x:Key="MaterialDesignPaper" Color="#D0D0D0"/>
+</ResourceDictionary>

--- a/UnoraLaunchpad/Resources/PeridotTheme.xaml
+++ b/UnoraLaunchpad/Resources/PeridotTheme.xaml
@@ -1,0 +1,44 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Background Colors -->
+    <SolidColorBrush x:Key="PrimaryBackgroundColor" Color="#233B00"/>
+    <SolidColorBrush x:Key="SecondaryBackgroundColor" Color="#375800"/>
+    <SolidColorBrush x:Key="TertiaryBackgroundColor" Color="#4B7400"/>
+
+    <!-- Title Bar Colors -->
+    <SolidColorBrush x:Key="TitleBarColor" Color="#659D00"/>
+    <SolidColorBrush x:Key="TitleBarTextColor" Color="#E8FFD1"/>
+
+    <!-- Text Colors -->
+    <SolidColorBrush x:Key="PrimaryTextColor" Color="#E8FFD1"/>
+    <SolidColorBrush x:Key="SecondaryTextColor" Color="#D6FFB3"/>
+    <SolidColorBrush x:Key="IconForegroundColor" Color="#D6FFB3"/>
+
+    <!-- Button Colors -->
+    <SolidColorBrush x:Key="ButtonBackgroundColor" Color="#659D00"/>
+    <SolidColorBrush x:Key="ButtonForegroundColor" Color="#E8FFD1"/>
+    <SolidColorBrush x:Key="ButtonTransparentBackgroundColor" Color="Transparent"/>
+
+    <!-- Border Colors -->
+    <SolidColorBrush x:Key="PrimaryBorderColor" Color="#D6FFB3"/>
+    <SolidColorBrush x:Key="SecondaryBorderColor" Color="#659D00"/>
+
+    <!-- Accent Colors -->
+    <SolidColorBrush x:Key="AccentColor1" Color="#80C000"/> <!-- Bright Green -->
+    <SolidColorBrush x:Key="AccentColor2" Color="#74B000"/>
+
+    <!-- Game Update Tile Specific -->
+    <SolidColorBrush x:Key="GameTileBackgroundColor" Color="#375800"/>
+    <SolidColorBrush x:Key="GameTileBorderColor" Color="#D6FFB3"/>
+    <SolidColorBrush x:Key="GameTileTextColor" Color="#E8FFD1"/>
+    <SolidColorBrush x:Key="GameTileDescriptionBackgroundColor" Color="#99233B00"/>
+
+    <!-- MaterialDesign Checkbox Colors -->
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxOff" Color="#D6FFB3"/>
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxChecked" Color="#80C000"/>
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxDisabled" Color="#659D00"/>
+    <SolidColorBrush x:Key="MaterialDesignBody" Color="#E8FFD1"/>
+    <SolidColorBrush x:Key="MaterialDesignBodyLight" Color="#D6FFB3"/>
+    <SolidColorBrush x:Key="MaterialDesignPaper" Color="#375800"/>
+</ResourceDictionary>

--- a/UnoraLaunchpad/Resources/RubyTheme.xaml
+++ b/UnoraLaunchpad/Resources/RubyTheme.xaml
@@ -1,0 +1,44 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Background Colors -->
+    <SolidColorBrush x:Key="PrimaryBackgroundColor" Color="#3B0000"/>
+    <SolidColorBrush x:Key="SecondaryBackgroundColor" Color="#5C0000"/>
+    <SolidColorBrush x:Key="TertiaryBackgroundColor" Color="#7C0000"/>
+
+    <!-- Title Bar Colors -->
+    <SolidColorBrush x:Key="TitleBarColor" Color="#A80000"/>
+    <SolidColorBrush x:Key="TitleBarTextColor" Color="#FFD1D1"/>
+
+    <!-- Text Colors -->
+    <SolidColorBrush x:Key="PrimaryTextColor" Color="#FFD1D1"/>
+    <SolidColorBrush x:Key="SecondaryTextColor" Color="#FFB3B3"/>
+    <SolidColorBrush x:Key="IconForegroundColor" Color="#FFB3B3"/>
+
+    <!-- Button Colors -->
+    <SolidColorBrush x:Key="ButtonBackgroundColor" Color="#A80000"/>
+    <SolidColorBrush x:Key="ButtonForegroundColor" Color="#FFD1D1"/>
+    <SolidColorBrush x:Key="ButtonTransparentBackgroundColor" Color="Transparent"/>
+
+    <!-- Border Colors -->
+    <SolidColorBrush x:Key="PrimaryBorderColor" Color="#FFB3B3"/>
+    <SolidColorBrush x:Key="SecondaryBorderColor" Color="#A80000"/>
+
+    <!-- Accent Colors -->
+    <SolidColorBrush x:Key="AccentColor1" Color="#FF0000"/> <!-- Bright Red -->
+    <SolidColorBrush x:Key="AccentColor2" Color="#D40000"/>
+
+    <!-- Game Update Tile Specific -->
+    <SolidColorBrush x:Key="GameTileBackgroundColor" Color="#5C0000"/>
+    <SolidColorBrush x:Key="GameTileBorderColor" Color="#FFB3B3"/>
+    <SolidColorBrush x:Key="GameTileTextColor" Color="#FFD1D1"/>
+    <SolidColorBrush x:Key="GameTileDescriptionBackgroundColor" Color="#993B0000"/>
+
+    <!-- MaterialDesign Checkbox Colors -->
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxOff" Color="#FFB3B3"/>
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxChecked" Color="#FF0000"/>
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxDisabled" Color="#A80000"/>
+    <SolidColorBrush x:Key="MaterialDesignBody" Color="#FFD1D1"/>
+    <SolidColorBrush x:Key="MaterialDesignBodyLight" Color="#FFB3B3"/>
+    <SolidColorBrush x:Key="MaterialDesignPaper" Color="#5C0000"/>
+</ResourceDictionary>

--- a/UnoraLaunchpad/Resources/SapphireTheme.xaml
+++ b/UnoraLaunchpad/Resources/SapphireTheme.xaml
@@ -1,0 +1,44 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Background Colors -->
+    <SolidColorBrush x:Key="PrimaryBackgroundColor" Color="#001F3B"/>
+    <SolidColorBrush x:Key="SecondaryBackgroundColor" Color="#003366"/>
+    <SolidColorBrush x:Key="TertiaryBackgroundColor" Color="#004080"/>
+
+    <!-- Title Bar Colors -->
+    <SolidColorBrush x:Key="TitleBarColor" Color="#0059b3"/>
+    <SolidColorBrush x:Key="TitleBarTextColor" Color="#D1E0FF"/>
+
+    <!-- Text Colors -->
+    <SolidColorBrush x:Key="PrimaryTextColor" Color="#D1E0FF"/>
+    <SolidColorBrush x:Key="SecondaryTextColor" Color="#B3CCFF"/>
+    <SolidColorBrush x:Key="IconForegroundColor" Color="#B3CCFF"/>
+
+    <!-- Button Colors -->
+    <SolidColorBrush x:Key="ButtonBackgroundColor" Color="#0059b3"/>
+    <SolidColorBrush x:Key="ButtonForegroundColor" Color="#D1E0FF"/>
+    <SolidColorBrush x:Key="ButtonTransparentBackgroundColor" Color="Transparent"/>
+
+    <!-- Border Colors -->
+    <SolidColorBrush x:Key="PrimaryBorderColor" Color="#B3CCFF"/>
+    <SolidColorBrush x:Key="SecondaryBorderColor" Color="#0059b3"/>
+
+    <!-- Accent Colors -->
+    <SolidColorBrush x:Key="AccentColor1" Color="#007FFF"/> <!-- Bright Blue -->
+    <SolidColorBrush x:Key="AccentColor2" Color="#0066CC"/>
+
+    <!-- Game Update Tile Specific -->
+    <SolidColorBrush x:Key="GameTileBackgroundColor" Color="#003366"/>
+    <SolidColorBrush x:Key="GameTileBorderColor" Color="#B3CCFF"/>
+    <SolidColorBrush x:Key="GameTileTextColor" Color="#D1E0FF"/>
+    <SolidColorBrush x:Key="GameTileDescriptionBackgroundColor" Color="#99001F3B"/>
+
+    <!-- MaterialDesign Checkbox Colors -->
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxOff" Color="#B3CCFF"/>
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxChecked" Color="#007FFF"/>
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxDisabled" Color="#0059b3"/>
+    <SolidColorBrush x:Key="MaterialDesignBody" Color="#D1E0FF"/>
+    <SolidColorBrush x:Key="MaterialDesignBodyLight" Color="#B3CCFF"/>
+    <SolidColorBrush x:Key="MaterialDesignPaper" Color="#003366"/>
+</ResourceDictionary>

--- a/UnoraLaunchpad/Resources/TopazTheme.xaml
+++ b/UnoraLaunchpad/Resources/TopazTheme.xaml
@@ -1,0 +1,44 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Background Colors -->
+    <SolidColorBrush x:Key="PrimaryBackgroundColor" Color="#4B3A00"/>
+    <SolidColorBrush x:Key="SecondaryBackgroundColor" Color="#725800"/>
+    <SolidColorBrush x:Key="TertiaryBackgroundColor" Color="#997600"/>
+
+    <!-- Title Bar Colors -->
+    <SolidColorBrush x:Key="TitleBarColor" Color="#CC9900"/>
+    <SolidColorBrush x:Key="TitleBarTextColor" Color="#FFF5D1"/>
+
+    <!-- Text Colors -->
+    <SolidColorBrush x:Key="PrimaryTextColor" Color="#FFF5D1"/>
+    <SolidColorBrush x:Key="SecondaryTextColor" Color="#FFEDB3"/>
+    <SolidColorBrush x:Key="IconForegroundColor" Color="#FFEDB3"/>
+
+    <!-- Button Colors -->
+    <SolidColorBrush x:Key="ButtonBackgroundColor" Color="#CC9900"/>
+    <SolidColorBrush x:Key="ButtonForegroundColor" Color="#FFF5D1"/>
+    <SolidColorBrush x:Key="ButtonTransparentBackgroundColor" Color="Transparent"/>
+
+    <!-- Border Colors -->
+    <SolidColorBrush x:Key="PrimaryBorderColor" Color="#FFEDB3"/>
+    <SolidColorBrush x:Key="SecondaryBorderColor" Color="#CC9900"/>
+
+    <!-- Accent Colors -->
+    <SolidColorBrush x:Key="AccentColor1" Color="#FFBF00"/> <!-- Bright Yellow/Orange -->
+    <SolidColorBrush x:Key="AccentColor2" Color="#E6AC00"/>
+
+    <!-- Game Update Tile Specific -->
+    <SolidColorBrush x:Key="GameTileBackgroundColor" Color="#725800"/>
+    <SolidColorBrush x:Key="GameTileBorderColor" Color="#FFEDB3"/>
+    <SolidColorBrush x:Key="GameTileTextColor" Color="#FFF5D1"/>
+    <SolidColorBrush x:Key="GameTileDescriptionBackgroundColor" Color="#994B3A00"/>
+
+    <!-- MaterialDesign Checkbox Colors -->
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxOff" Color="#FFEDB3"/>
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxChecked" Color="#FFBF00"/>
+    <SolidColorBrush x:Key="MaterialDesignCheckBoxDisabled" Color="#CC9900"/>
+    <SolidColorBrush x:Key="MaterialDesignBody" Color="#FFF5D1"/>
+    <SolidColorBrush x:Key="MaterialDesignBodyLight" Color="#FFEDB3"/>
+    <SolidColorBrush x:Key="MaterialDesignPaper" Color="#725800"/>
+</ResourceDictionary>

--- a/UnoraLaunchpad/SettingsWindow.xaml
+++ b/UnoraLaunchpad/SettingsWindow.xaml
@@ -95,10 +95,20 @@
                                       SelectionChanged="ThemeComboBox_SelectionChanged"
                                       Foreground="{DynamicResource IconForegroundColor}">
                                 <ComboBoxItem Content="Amber"/>
+                                <ComboBoxItem Content="Amethyst"/>
+                                <ComboBoxItem Content="Aquamarine"/>
+                                <ComboBoxItem Content="Citrine"/>
                                 <ComboBoxItem Content="Dark"/>
                                 <ComboBoxItem Content="Emerald"/>
+                                <ComboBoxItem Content="Garnet"/>
                                 <ComboBoxItem Content="Light"/>
+                                <ComboBoxItem Content="Obsidian"/>
+                                <ComboBoxItem Content="Pearl"/>
+                                <ComboBoxItem Content="Peridot"/>
+                                <ComboBoxItem Content="Ruby"/>
+                                <ComboBoxItem Content="Sapphire"/>
                                 <ComboBoxItem Content="Teal"/>
+                                <ComboBoxItem Content="Topaz"/>
                                 <ComboBoxItem Content="Violet"/>
                             </ComboBox>
                         </StackPanel>

--- a/UnoraLaunchpad/SettingsWindow.xaml.cs
+++ b/UnoraLaunchpad/SettingsWindow.xaml.cs
@@ -18,7 +18,17 @@ internal sealed partial class SettingsWindow : Window
         { "Teal",  "pack://application:,,,/Resources/TealTheme.xaml" },
         { "Violet", "pack://application:,,,/Resources/VioletTheme.xaml" },
         { "Amber", "pack://application:,,,/Resources/AmberTheme.xaml" },
-        { "Emerald", "pack://application:,,,/Resources/EmeraldTheme.xaml" }
+        { "Emerald", "pack://application:,,,/Resources/EmeraldTheme.xaml" },
+        { "Ruby", "pack://application:,,,/Resources/RubyTheme.xaml" },
+        { "Sapphire", "pack://application:,,,/Resources/SapphireTheme.xaml" },
+        { "Topaz", "pack://application:,,,/Resources/TopazTheme.xaml" },
+        { "Amethyst", "pack://application:,,,/Resources/AmethystTheme.xaml" },
+        { "Garnet", "pack://application:,,,/Resources/GarnetTheme.xaml" },
+        { "Pearl", "pack://application:,,,/Resources/PearlTheme.xaml" },
+        { "Obsidian", "pack://application:,,,/Resources/ObsidianTheme.xaml" },
+        { "Citrine", "pack://application:,,,/Resources/CitrineTheme.xaml" },
+        { "Peridot", "pack://application:,,,/Resources/PeridotTheme.xaml" },
+        { "Aquamarine", "pack://application:,,,/Resources/AquamarineTheme.xaml" }
     };
 
 


### PR DESCRIPTION
This commit introduces 10 new color themes:
- Ruby
- Sapphire
- Topaz
- Amethyst
- Garnet
- Pearl
- Obsidian
- Citrine
- Peridot
- Aquamarine

The following files were modified to support these new themes:
- New XAML files for each theme were added to `UnoraLaunchpad/Resources/`.
- `UnoraLaunchpad/App.xaml.cs`: Updated to recognize and load the new theme files.
- `UnoraLaunchpad/MainWindow.xaml.cs`: Updated to correctly apply the new themes.
- `UnoraLaunchpad/SettingsWindow.xaml.cs`: Updated the `ThemeResourceMap` to include the new themes.
- `UnoraLaunchpad/SettingsWindow.xaml`: Updated the `ThemeComboBox` to list the new themes for selection.

Note: Due to environmental limitations (.NET Framework 4.8 project in a Linux-based build environment), I could not perform automated testing of these themes. Manual testing on a Windows environment is required to ensure correct application and appearance of the new themes.