### PR TITLE
Fix: Include new theme files in .csproj

### DIFF
--- a/UnoraLaunchpad/UnoraLaunchpad.csproj
+++ b/UnoraLaunchpad/UnoraLaunchpad.csproj
@@ -119,6 +119,16 @@
     <Page Include="Resources\LightTheme.xaml" />
     <Page Include="Resources\TealTheme.xaml" />
     <Page Include="Resources\VioletTheme.xaml" />
+    <Page Include="Resources\RubyTheme.xaml" />
+    <Page Include="Resources\SapphireTheme.xaml" />
+    <Page Include="Resources\TopazTheme.xaml" />
+    <Page Include="Resources\AmethystTheme.xaml" />
+    <Page Include="Resources\GarnetTheme.xaml" />
+    <Page Include="Resources\PearlTheme.xaml" />
+    <Page Include="Resources\ObsidianTheme.xaml" />
+    <Page Include="Resources\CitrineTheme.xaml" />
+    <Page Include="Resources\PeridotTheme.xaml" />
+    <Page Include="Resources\AquamarineTheme.xaml" />
     <Page Include="SettingsWindow.xaml" />
     <Page Include="SwirlLoader.xaml" />
     <Page Include="UpdateLockWIndow.xaml" />


### PR DESCRIPTION
This commit updates UnoraLaunchpad.csproj to include the 10 new XAML theme files as Page resources. This was missed in the previous commit and is necessary for the themes to be correctly compiled with the application.

The new themes added are:
- RubyTheme.xaml
- SapphireTheme.xaml
- TopazTheme.xaml
- AmethystTheme.xaml
- GarnetTheme.xaml
- PearlTheme.xaml
- ObsidianTheme.xaml
- CitrineTheme.xaml
- PeridotTheme.xaml
- AquamarineTheme.xaml