### PR TITLE
feat: Implement global macro execution system

### DIFF
--- a/UnoraLaunchpad/Launcher/NativeMethods.cs
+++ b/UnoraLaunchpad/Launcher/NativeMethods.cs
@@ -191,4 +191,91 @@ internal static class NativeMethods
     [DllImport("User32.dll")]
     public static extern int SetForegroundWindow(int hWnd);
     #endregion
+
+    #region Global Hotkeys
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+
+    // Modifiers for RegisterHotKey
+    public const uint MOD_NONE = 0x0000;
+    public const uint MOD_ALT = 0x0001;
+    public const uint MOD_CONTROL = 0x0002;
+    public const uint MOD_SHIFT = 0x0004;
+    public const uint MOD_WIN = 0x0008;
+
+    #endregion
+
+    #region SendInput related (though InputSimulatorStandard handles this, good for reference or direct use if needed)
+    // INPUT structure
+    [StructLayout(LayoutKind.Sequential)]
+    public struct INPUT
+    {
+        public uint type;
+        public InputUnion U;
+        public static int Size
+        {
+            get { return Marshal.SizeOf(typeof(INPUT)); }
+        }
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct InputUnion
+    {
+        [FieldOffset(0)]
+        public MOUSEINPUT mi;
+        [FieldOffset(0)]
+        public KEYBDINPUT ki;
+        [FieldOffset(0)]
+        public HARDWAREINPUT hi;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MOUSEINPUT
+    {
+        public int dx;
+        public int dy;
+        public uint mouseData;
+        public uint dwFlags;
+        public uint time;
+        public IntPtr dwExtraInfo;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct KEYBDINPUT
+    {
+        public ushort wVk;
+        public ushort wScan;
+        public uint dwFlags;
+        public uint time;
+        public IntPtr dwExtraInfo;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct HARDWAREINPUT
+    {
+        public uint uMsg;
+        public ushort wParamL;
+        public ushort wParamH;
+    }
+
+    // dwFlags for KEYBDINPUT
+    public const uint KEYEVENTF_EXTENDEDKEY = 0x0001;
+    public const uint KEYEVENTF_KEYUP = 0x0002;
+    public const uint KEYEVENTF_UNICODE = 0x0004;
+    public const uint KEYEVENTF_SCANCODE = 0x0008;
+
+    // Input Types
+    public const uint INPUT_MOUSE = 0;
+    public const uint INPUT_KEYBOARD = 1;
+    public const uint INPUT_HARDWARE = 2;
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+
+    #endregion
 }

--- a/UnoraLaunchpad/MacroParser.cs
+++ b/UnoraLaunchpad/MacroParser.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Windows.Input; // For Key and ModifierKeys
+using InputSimulatorStandard.Native; // For VirtualKeyCode
+
+namespace UnoraLaunchpad
+{
+    internal static class MacroParser
+    {
+        public static bool TryParseTriggerKey(string triggerKeyString, out uint modifiers, out uint vkCode)
+        {
+            modifiers = NativeMethods.MOD_NONE;
+            vkCode = 0;
+
+            if (string.IsNullOrWhiteSpace(triggerKeyString)) return false;
+
+            var parts = triggerKeyString.Split(new[] { '+' }, StringSplitOptions.RemoveEmptyEntries);
+            if (!parts.Any()) return false;
+
+            string keyPart = parts.Last().Trim();
+            Key wpfKey;
+
+            try
+            {
+                wpfKey = (Key)Enum.Parse(typeof(Key), keyPart, true);
+            }
+            catch (ArgumentException)
+            {
+                // Check for common names like PageDown, PageUp, etc.
+                // WPF's Key enum is quite comprehensive.
+                // This could be expanded if specific non-standard names are used.
+                System.Diagnostics.Debug.WriteLine($"[MacroParser] Could not parse key: {keyPart}");
+                return false;
+            }
+
+            vkCode = (uint)KeyInterop.VirtualKeyFromKey(wpfKey);
+            if (vkCode == 0) return false;
+
+
+            for (int i = 0; i < parts.Length - 1; i++)
+            {
+                switch (parts[i].Trim().ToUpperInvariant())
+                {
+                    case "CTRL":
+                    case "CONTROL":
+                        modifiers |= NativeMethods.MOD_CONTROL;
+                        break;
+                    case "SHIFT":
+                        modifiers |= NativeMethods.MOD_SHIFT;
+                        break;
+                    case "ALT":
+                        modifiers |= NativeMethods.MOD_ALT;
+                        break;
+                    case "WIN":
+                    case "WINDOWS":
+                        modifiers |= NativeMethods.MOD_WIN;
+                        break;
+                    // default: // Unknown modifier
+                        // System.Diagnostics.Debug.WriteLine($"[MacroParser] Unknown modifier: {parts[i]}");
+                        // return false;
+                        // Allow unknown parts for now, maybe they are part of the key name if not split well.
+                }
+            }
+            return true;
+        }
+
+        public static List<MacroAction> ParseActionSequence(string sequence)
+        {
+            var actions = new List<MacroAction>();
+            if (string.IsNullOrWhiteSpace(sequence)) return actions;
+
+            // Regex to find commands like SendText "text", Wait Nms, KeyPress VK_CODE, KeyDown VK_CODE, KeyUp VK_CODE
+            // Example: SendText "Hello World"{ENTER} Wait 500ms KeyPress LControlKey KeyPress C KeyUp C KeyUp LControlKey
+            // This is a simplified parser. A more robust one would handle escaping quotes within SendText etc.
+            var regex = new Regex(@"(SendText\s*""([^""]*)""|Wait\s*(\d+)\s*ms|KeyPress\s*([A-Za-z0-9_]+)|KeyDown\s*([A-Za-z0-9_]+)|KeyUp\s*([A-Za-z0-9_]+)|SendKey\s*([A-Za-z0-9_]+(?:{[A-Z]+})*))", RegexOptions.IgnoreCase);
+            var matches = regex.Matches(sequence);
+
+            foreach (Match match in matches)
+            {
+                if (match.Groups[1].Value.StartsWith("SendText", StringComparison.OrdinalIgnoreCase))
+                {
+                    string text = match.Groups[2].Value;
+                    // Replace common placeholders like {ENTER}
+                    text = text.Replace("{ENTER}", "\n").Replace("{TAB}", "\t");
+                    actions.Add(new MacroAction { Type = MacroActionType.SendText, Argument = text });
+                }
+                else if (match.Groups[1].Value.StartsWith("Wait", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (int.TryParse(match.Groups[3].Value, out int delay))
+                    {
+                        actions.Add(new MacroAction { Type = MacroActionType.Wait, Argument = delay });
+                    }
+                }
+                else if (match.Groups[1].Value.StartsWith("KeyPress", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (Enum.TryParse<VirtualKeyCode>(match.Groups[4].Value, true, out var vk))
+                    {
+                        actions.Add(new MacroAction { Type = MacroActionType.KeyPress, Argument = vk });
+                    }
+                }
+                else if (match.Groups[1].Value.StartsWith("KeyDown", StringComparison.OrdinalIgnoreCase))
+                {
+                     if (Enum.TryParse<VirtualKeyCode>(match.Groups[5].Value, true, out var vk))
+                    {
+                        actions.Add(new MacroAction { Type = MacroActionType.KeyDown, Argument = vk });
+                    }
+                }
+                else if (match.Groups[1].Value.StartsWith("KeyUp", StringComparison.OrdinalIgnoreCase))
+                {
+                     if (Enum.TryParse<VirtualKeyCode>(match.Groups[6].Value, true, out var vk))
+                    {
+                        actions.Add(new MacroAction { Type = MacroActionType.KeyUp, Argument = vk });
+                    }
+                }
+                 else if (match.Groups[1].Value.StartsWith("SendKey", StringComparison.OrdinalIgnoreCase))
+                {
+                    // This is a more direct approach for simple single key presses or text with special keys
+                    // Example: SendKey A, SendKey {ENTER}, SendKey Hello{TAB}World
+                    // This will be handled by InputSimulator.Keyboard.TextEntry for sequences like "Hello"
+                    // and specific key presses for things like {ENTER}
+                    actions.Add(new MacroAction { Type = MacroActionType.SendKeySequence, Argument = match.Groups[7].Value });
+                }
+            }
+            return actions;
+        }
+    }
+
+    public enum MacroActionType
+    {
+        SendText,    // Argument is string
+        Wait,        // Argument is int (milliseconds)
+        KeyPress,    // Argument is VirtualKeyCode
+        KeyDown,     // Argument is VirtualKeyCode
+        KeyUp,       // Argument is VirtualKeyCode
+        SendKeySequence // Argument is string (e.g. "A", "{ENTER}", "Ctrl+C") - for more complex input sim
+    }
+
+    public struct MacroAction
+    {
+        public MacroActionType Type { get; set; }
+        public object Argument { get; set; }
+    }
+}

--- a/UnoraLaunchpad/MacroWindow.xaml
+++ b/UnoraLaunchpad/MacroWindow.xaml
@@ -1,0 +1,168 @@
+<Window x:Class="UnoraLaunchpad.MacroWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        Title="Macro Settings"
+        Height="550"
+        Width="450"
+        WindowStyle="None"
+        ResizeMode="CanResize"
+        WindowStartupLocation="CenterScreen"
+        TextElement.Foreground="{DynamicResource PrimaryTextColor}"
+        Background="{DynamicResource PrimaryBackgroundColor}"
+        BorderBrush="{DynamicResource PrimaryBorderColor}"
+        BorderThickness="2"
+        TextElement.FontWeight="Medium"
+        TextElement.FontSize="14"
+        FontFamily="{materialDesign:MaterialDesignFont}"
+        x:ClassModifier="internal"
+        Loaded="MacroWindow_Loaded">
+
+    <Window.Resources>
+        <Style TargetType="ComboBox" BasedOn="{StaticResource MaterialDesignComboBox}">
+            <Setter Property="Background" Value="{DynamicResource SecondaryBackgroundColor}" />
+            <Setter Property="Foreground" Value="{DynamicResource PrimaryTextColor}" />
+        </Style>
+        <Style TargetType="TextBox" BasedOn="{StaticResource MaterialDesignTextBox}">
+            <Setter Property="Background" Value="{DynamicResource SecondaryBackgroundColor}" />
+            <Setter Property="Foreground" Value="{DynamicResource PrimaryTextColor}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource PrimaryBorderColor}" />
+        </Style>
+        <Style TargetType="ListBox" BasedOn="{StaticResource MaterialDesignListBox}">
+            <Setter Property="Background" Value="{DynamicResource SecondaryBackgroundColor}" />
+            <Setter Property="Foreground" Value="{DynamicResource PrimaryTextColor}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource PrimaryBorderColor}" />
+        </Style>
+    </Window.Resources>
+
+    <Grid Background="{DynamicResource PrimaryBackgroundColor}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="30" /> <!-- Custom Title Bar -->
+            <RowDefinition Height="*" /> <!-- Main Content -->
+            <RowDefinition Height="45" /> <!-- Bottom Bar -->
+        </Grid.RowDefinitions>
+
+        <!-- Custom Title Bar -->
+        <Grid Grid.Row="0"
+              Background="{DynamicResource TitleBarColor}"
+              MouseDown="TitleBar_MouseDown">
+            <Button HorizontalAlignment="Right"
+                    VerticalAlignment="Center"
+                    Foreground="{DynamicResource IconForegroundColor}"
+                    Background="{DynamicResource ButtonTransparentBackgroundColor}"
+                    BorderBrush="{DynamicResource ButtonTransparentBackgroundColor}"
+                    Padding="0"
+                    Margin="5"
+                    Cursor="Hand"
+                    Click="CloseButton_Click">
+                <materialDesign:PackIcon Kind="Close" />
+            </Button>
+            <Label Content="Macro Settings"
+                   Foreground="{DynamicResource TitleBarTextColor}"
+                   HorizontalAlignment="Left"
+                   VerticalAlignment="Center" />
+        </Grid>
+
+        <!-- Main Content -->
+        <Grid Grid.Row="1" Background="{DynamicResource SecondaryBackgroundColor}">
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <StackPanel HorizontalAlignment="Stretch" VerticalAlignment="Top" Margin="10">
+
+                    <CheckBox x:Name="EnableMacrosCheckBox"
+                              Content="Enable Macro System"
+                              Foreground="{DynamicResource IconForegroundColor}"
+                              Background="{DynamicResource PrimaryTextColor}"
+                              HorizontalAlignment="Center"
+                              VerticalAlignment="Center"
+                              Margin="0,0,0,10"/>
+
+                    <GroupBox Header="Macros"
+                              Margin="0,10,0,0"
+                              Foreground="{DynamicResource PrimaryTextColor}"
+                              BorderBrush="{DynamicResource PrimaryBorderColor}">
+                        <StackPanel>
+                            <ListBox x:Name="MacrosListBox"
+                                     Height="150"
+                                     Margin="5"
+                                     SelectionChanged="MacrosListBox_SelectionChanged">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock Text="{Binding Key}" FontWeight="Bold" Margin="0,0,10,0" MinWidth="100"/>
+                                            <TextBlock Text="{Binding Value}" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                            <Grid Margin="5">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <StackPanel Grid.Column="0" Margin="0,0,10,0">
+                                    <TextBlock Text="Trigger Key (e.g., F1, PageDown, Ctrl+Shift+A):" Foreground="{DynamicResource PrimaryTextColor}" />
+                                    <TextBox x:Name="MacroTriggerKeyTextBox" />
+                                    <TextBlock Text="Action Sequence (e.g., SendText Hello{ENTER}Wait 500ms):" Margin="0,5,0,0" Foreground="{DynamicResource PrimaryTextColor}" />
+                                    <TextBox x:Name="MacroActionSequenceTextBox" />
+                                </StackPanel>
+                                <Button x:Name="AddMacroButton"
+                                        Content="Add"
+                                        Grid.Column="1"
+                                        Click="AddMacroButton_Click"
+                                        VerticalAlignment="Bottom"
+                                        Margin="5,0"
+                                        Style="{StaticResource MaterialDesignRaisedLightButton}"
+                                        Background="{DynamicResource ButtonBackgroundColor}"
+                                        Foreground="{DynamicResource ButtonForegroundColor}"
+                                        materialDesign:ButtonAssist.CornerRadius="5"/>
+                                <Button x:Name="EditMacroButton"
+                                        Content="Update"
+                                        Grid.Column="2"
+                                        Click="EditMacroButton_Click"
+                                        VerticalAlignment="Bottom"
+                                        Margin="5,0"
+                                        Style="{StaticResource MaterialDesignRaisedLightButton}"
+                                        Background="{DynamicResource ButtonBackgroundColor}"
+                                        Foreground="{DynamicResource ButtonForegroundColor}"
+                                        materialDesign:ButtonAssist.CornerRadius="5"/>
+                                <Button x:Name="RemoveMacroButton"
+                                        Content="Remove"
+                                        Grid.Column="3"
+                                        Click="RemoveMacroButton_Click"
+                                        VerticalAlignment="Bottom"
+                                        Margin="5,0"
+                                        Style="{StaticResource MaterialDesignRaisedLightButton}"
+                                        Background="{DynamicResource ButtonBackgroundColor}"
+                                        Foreground="{DynamicResource ButtonForegroundColor}"
+                                        materialDesign:ButtonAssist.CornerRadius="5"/>
+                            </Grid>
+                        </StackPanel>
+                    </GroupBox>
+                </StackPanel>
+            </ScrollViewer>
+        </Grid>
+
+        <!-- Bottom Bar -->
+        <Grid Grid.Row="2" Background="{DynamicResource TitleBarColor}">
+            <Button x:Name="SaveAndCloseBtn"
+                    Click="SaveAndCloseBtn_Click"
+                    Width="120"
+                    Height="30"
+                    materialDesign:ButtonAssist.CornerRadius="5"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Center"
+                    Foreground="{DynamicResource ButtonForegroundColor}"
+                    Background="{DynamicResource ButtonBackgroundColor}"
+                    Margin="0,0,20,0"
+                    Style="{StaticResource MaterialDesignRaisedLightButton}"
+                    ToolTip="Save macro settings and close.">
+                <TextBlock Text="Save &amp; Close" />
+            </Button>
+        </Grid>
+    </Grid>
+</Window>

--- a/UnoraLaunchpad/MacroWindow.xaml.cs
+++ b/UnoraLaunchpad/MacroWindow.xaml.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace UnoraLaunchpad
+{
+    internal partial class MacroWindow : Window
+    {
+        private readonly Settings _settings;
+        private readonly MainWindow _mainWindow; // To call ApplyMacroSettingsAndSave
+
+        // Use a local list for editing, then apply to _settings.Macros on save
+        private List<KeyValuePair<string, string>> _localMacros;
+
+        public MacroWindow(MainWindow mainWindow, Settings settings)
+        {
+            InitializeComponent();
+            _mainWindow = mainWindow;
+            _settings = settings;
+
+            // Deep copy for local editing to avoid modifying original _settings.Macros directly until save
+            _localMacros = _settings.Macros?.Select(kvp => new KeyValuePair<string, string>(kvp.Key, kvp.Value)).ToList()
+                           ?? new List<KeyValuePair<string, string>>();
+        }
+
+        private void MacroWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            EnableMacrosCheckBox.IsChecked = _settings.IsMacroSystemEnabled;
+            RefreshMacrosListBox();
+            UpdateButtonsState();
+        }
+
+        private void TitleBar_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (e.ChangedButton == MouseButton.Left)
+                DragMove();
+        }
+
+        private void CloseButton_Click(object sender, RoutedEventArgs e)
+        {
+            // Offer to save if changes were made? For now, just close.
+            // Or, consider if "Save & Close" is the only way to persist.
+            // If user clicks 'X', changes are lost unless explicitly saved.
+            this.Close();
+        }
+
+        private void SaveAndCloseBtn_Click(object sender, RoutedEventArgs e)
+        {
+            // Update the main settings object from local changes
+            _settings.IsMacroSystemEnabled = EnableMacrosCheckBox.IsChecked ?? false;
+
+            // Convert the local list back to dictionary for saving
+            _settings.Macros.Clear();
+            foreach (var kvp in _localMacros)
+            {
+                _settings.Macros[kvp.Key] = kvp.Value;
+            }
+
+            _mainWindow.ApplyMacroSettingsAndSave(); // This will save all settings and re-register hotkeys
+            this.Close();
+        }
+
+        private void MacrosListBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (MacrosListBox.SelectedItem is KeyValuePair<string, string> selectedMacro)
+            {
+                MacroTriggerKeyTextBox.Text = selectedMacro.Key;
+                MacroActionSequenceTextBox.Text = selectedMacro.Value;
+            }
+            else
+            {
+                MacroTriggerKeyTextBox.Text = string.Empty;
+                MacroActionSequenceTextBox.Text = string.Empty;
+            }
+            UpdateButtonsState();
+        }
+
+        private void AddMacroButton_Click(object sender, RoutedEventArgs e)
+        {
+            var triggerKey = MacroTriggerKeyTextBox.Text.Trim();
+            var actionSequence = MacroActionSequenceTextBox.Text.Trim();
+
+            if (string.IsNullOrWhiteSpace(triggerKey))
+            {
+                MessageBox.Show("Trigger key cannot be empty.", "Add Macro", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+            if (string.IsNullOrWhiteSpace(actionSequence))
+            {
+                MessageBox.Show("Action sequence cannot be empty.", "Add Macro", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+            if (_localMacros.Any(m => m.Key.Equals(triggerKey, StringComparison.OrdinalIgnoreCase)))
+            {
+                MessageBox.Show("A macro with this trigger key already exists.", "Add Macro", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            _localMacros.Add(new KeyValuePair<string, string>(triggerKey, actionSequence));
+            RefreshMacrosListBox();
+            MacroTriggerKeyTextBox.Text = string.Empty;
+            MacroActionSequenceTextBox.Text = string.Empty;
+            MacrosListBox.SelectedItem = _localMacros.LastOrDefault(); // Select the newly added item
+        }
+
+        private void EditMacroButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (MacrosListBox.SelectedItem is KeyValuePair<string, string> selectedMacro)
+            {
+                var originalKey = selectedMacro.Key;
+                var updatedTriggerKey = MacroTriggerKeyTextBox.Text.Trim();
+                var updatedActionSequence = MacroActionSequenceTextBox.Text.Trim();
+
+                if (string.IsNullOrWhiteSpace(updatedTriggerKey))
+                {
+                    MessageBox.Show("Trigger key cannot be empty.", "Update Macro", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    return;
+                }
+                if (string.IsNullOrWhiteSpace(updatedActionSequence))
+                {
+                    MessageBox.Show("Action sequence cannot be empty.", "Update Macro", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    return;
+                }
+
+                // Check for new key conflict if key was changed
+                if (!originalKey.Equals(updatedTriggerKey, StringComparison.OrdinalIgnoreCase) &&
+                    _localMacros.Any(m => m.Key.Equals(updatedTriggerKey, StringComparison.OrdinalIgnoreCase)))
+                {
+                    MessageBox.Show("Another macro with this trigger key already exists.", "Update Macro", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    return;
+                }
+
+                // Find and update in the local list
+                var itemIndex = _localMacros.FindIndex(m => m.Key.Equals(originalKey, StringComparison.OrdinalIgnoreCase));
+                if (itemIndex != -1)
+                {
+                    _localMacros[itemIndex] = new KeyValuePair<string, string>(updatedTriggerKey, updatedActionSequence);
+                    RefreshMacrosListBox();
+                    MacrosListBox.SelectedItem = _localMacros[itemIndex]; // Reselect the updated item
+                }
+            }
+        }
+
+        private void RemoveMacroButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (MacrosListBox.SelectedItem is KeyValuePair<string, string> selectedMacro)
+            {
+                var result = MessageBox.Show($"Are you sure you want to remove the macro for '{selectedMacro.Key}'?",
+                                             "Remove Macro", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+                if (result == MessageBoxResult.Yes)
+                {
+                    _localMacros.RemoveAll(m => m.Key.Equals(selectedMacro.Key, StringComparison.OrdinalIgnoreCase));
+                    RefreshMacrosListBox();
+                }
+            }
+        }
+
+        private void RefreshMacrosListBox()
+        {
+            var previouslySelected = MacrosListBox.SelectedItem;
+            MacrosListBox.ItemsSource = null;
+            // Sort macros by key for consistent display, could be optional
+            MacrosListBox.ItemsSource = _localMacros.OrderBy(m => m.Key).ToList();
+
+            if (previouslySelected != null && _localMacros.Any(m => m.Key.Equals(((KeyValuePair<string,string>)previouslySelected).Key)))
+            {
+                 MacrosListBox.SelectedItem = _localMacros.First(m => m.Key.Equals(((KeyValuePair<string,string>)previouslySelected).Key));
+            }
+            else if (MacrosListBox.Items.Count > 0)
+            {
+                MacrosListBox.SelectedIndex = 0;
+            }
+            UpdateButtonsState();
+        }
+
+        private void UpdateButtonsState()
+        {
+            bool isItemSelected = MacrosListBox.SelectedItem != null;
+            EditMacroButton.IsEnabled = isItemSelected;
+            RemoveMacroButton.IsEnabled = isItemSelected;
+        }
+    }
+}

--- a/UnoraLaunchpad/MainWindow.xaml
+++ b/UnoraLaunchpad/MainWindow.xaml
@@ -85,7 +85,7 @@
               MouseDown="TitleBar_MouseDown">
             <!-- Patch Notes Button -->
             <Button HorizontalAlignment="Right"
-                    Margin="0, 0, 190, 0"
+                    Margin="0, 0, 235, 0" <!-- Adjusted Margin -->
                     Click="PatchNotesButton_Click"
                     Background="{DynamicResource ButtonTransparentBackgroundColor}"
                     Foreground="{DynamicResource IconForegroundColor}"
@@ -95,7 +95,7 @@
             </Button>
             <!-- Discord Button -->
             <Button HorizontalAlignment="Right"
-                    Margin="0, 0, 147, 0"
+                    Margin="0, 0, 191, 0" <!-- Adjusted Margin -->
                     Click="DiscordButton_Click"
                     Background="{DynamicResource ButtonTransparentBackgroundColor}"
                     Foreground="{DynamicResource IconForegroundColor}"
@@ -104,9 +104,21 @@
                 <materialDesign:PackIcon Kind="MessageText" />
             </Button>
 
+            <!-- Macro Settings Button -->
+            <Button HorizontalAlignment="Right"
+                    Margin="0, 0, 147, 0" <!-- Correct Margin -->
+                    Click="MacroButton_Click"
+                    Background="{DynamicResource ButtonTransparentBackgroundColor}"
+                    Foreground="{DynamicResource IconForegroundColor}"
+                    BorderBrush="{DynamicResource ButtonTransparentBackgroundColor}"
+                    shell:WindowChrome.IsHitTestVisibleInChrome="True"
+                    ToolTip="Open Macro Settings">
+                <materialDesign:PackIcon Kind="KeyboardSettings" />
+            </Button>
+
             <!-- Settings Button -->
             <Button HorizontalAlignment="Right"
-                    Margin="0, 0, 103, 0"
+                    Margin="0, 0, 103, 0" <!-- Unchanged -->
                     Click="CogButton_Click"
                     Background="{DynamicResource ButtonTransparentBackgroundColor}"
                     Foreground="{DynamicResource IconForegroundColor}"

--- a/UnoraLaunchpad/Settings.cs
+++ b/UnoraLaunchpad/Settings.cs
@@ -14,4 +14,6 @@ public sealed class Settings
     public double WindowTop { get; set; }
     public double WindowLeft { get; set; }
     public List<Character> SavedCharacters { get; set; } = [];
+    public Dictionary<string, string> Macros { get; set; } = [];
+    public bool IsMacroSystemEnabled { get; set; } = false;
 }

--- a/UnoraLaunchpad/SettingsWindow.xaml
+++ b/UnoraLaunchpad/SettingsWindow.xaml
@@ -204,6 +204,81 @@
                             </Grid>
                         </StackPanel>
                     </GroupBox>
+
+                    <!-- New Macros Section -->
+                    <GroupBox Header="Macros"
+                              Margin="0,20,0,0"
+                              Foreground="{DynamicResource PrimaryTextColor}"
+                              BorderBrush="{DynamicResource PrimaryBorderColor}">
+                        <StackPanel>
+                            <ListBox x:Name="MacrosListBox"
+                                     Height="100"
+                                     Margin="5"
+                                     Background="{DynamicResource SecondaryBackgroundColor}"
+                                     Foreground="{DynamicResource PrimaryTextColor}"
+                                     BorderBrush="{DynamicResource PrimaryBorderColor}"
+                                     SelectionChanged="MacrosListBox_SelectionChanged">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock Text="{Binding Key}" FontWeight="Bold" Margin="0,0,5,0" />
+                                            <TextBlock Text="{Binding Value}" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                            <Grid Margin="5">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <StackPanel Grid.Column="0" Margin="0,0,10,0">
+                                    <TextBlock Text="Trigger Key:" Foreground="{DynamicResource PrimaryTextColor}" />
+                                    <TextBox x:Name="MacroTriggerKeyTextBox"
+                                             Background="{DynamicResource SecondaryBackgroundColor}"
+                                             Foreground="{DynamicResource PrimaryTextColor}"
+                                             BorderBrush="{DynamicResource PrimaryBorderColor}" />
+                                    <TextBlock Text="Action Sequence:" Margin="0,5,0,0" Foreground="{DynamicResource PrimaryTextColor}" />
+                                    <TextBox x:Name="MacroActionSequenceTextBox"
+                                             Background="{DynamicResource SecondaryBackgroundColor}"
+                                             Foreground="{DynamicResource PrimaryTextColor}"
+                                             BorderBrush="{DynamicResource PrimaryBorderColor}" />
+                                </StackPanel>
+                                <Button x:Name="AddMacroButton"
+                                        Content="Add"
+                                        Grid.Column="1"
+                                        Click="AddMacroButton_Click"
+                                        VerticalAlignment="Bottom"
+                                        Margin="5,0"
+                                        Style="{StaticResource MaterialDesignRaisedLightButton}"
+                                        Background="{DynamicResource ButtonBackgroundColor}"
+                                        Foreground="{DynamicResource ButtonForegroundColor}"
+                                        materialDesign:ButtonAssist.CornerRadius="5"/>
+                                <Button x:Name="EditMacroButton"
+                                        Content="Update"
+                                        Grid.Column="2"
+                                        Click="EditMacroButton_Click"
+                                        VerticalAlignment="Bottom"
+                                        Margin="5,0"
+                                        Style="{StaticResource MaterialDesignRaisedLightButton}"
+                                        Background="{DynamicResource ButtonBackgroundColor}"
+                                        Foreground="{DynamicResource ButtonForegroundColor}"
+                                        materialDesign:ButtonAssist.CornerRadius="5"/>
+                                <Button x:Name="RemoveMacroButton"
+                                        Content="Remove"
+                                        Grid.Column="3"
+                                        Click="RemoveMacroButton_Click"
+                                        VerticalAlignment="Bottom"
+                                        Margin="5,0"
+                                        Style="{StaticResource MaterialDesignRaisedLightButton}"
+                                        Background="{DynamicResource ButtonBackgroundColor}"
+                                        Foreground="{DynamicResource ButtonForegroundColor}"
+                                        materialDesign:ButtonAssist.CornerRadius="5"/>
+                            </Grid>
+                        </StackPanel>
+                    </GroupBox>
                 </StackPanel>
             </ScrollViewer>
         </Grid>


### PR DESCRIPTION
Adds a comprehensive system for users to define and use global macros directly from the launcher. Macros can send sequences of keystrokes and commands to a target game window, even when the launcher is minimized.

Key changes:
- Added `IsMacroSystemEnabled` to `Settings.cs`.
- Created `MacroWindow.xaml` and `MacroWindow.xaml.cs` for a dedicated macro configuration UI, including enabling/disabling the system, and CRUD for macros.
- Added a button to `MainWindow.xaml` to open the `MacroWindow`.
- Significantly updated `MainWindow.xaml.cs` to:
    - Manage global hotkey registration/unregistration (using P/Invoke `RegisterHotKey`).
    - Listen for hotkey presses via `WndProc`.
    - Identify the target game window (currently by title "Unora").
    - Parse macro action sequences (defined in `MacroParser.cs`).
    - Simulate input to the target window using `InputSimulatorStandard`.
    - Handle application lifecycle for hotkeys (startup, shutdown, settings changes).
- Created `MacroParser.cs` to parse trigger key strings (e.g., "Ctrl+Shift+F1") into modifiers and virtual key codes, and to parse action sequence strings (e.g., "SendText Hello{ENTER} Wait 500ms") into a list of structured actions.
- Updated `NativeMethods.cs` with P/Invoke signatures for hotkey and window management APIs.
- Ensured properties like `SkipIntro`, `UseDawndWindower`, `UseLocalhost` consistently use the main `_launcherSettings` object.

This feature allows users to configure macros (e.g., "F1" -> "SendText /wave{ENTER}") that will execute in the specified game window when the corresponding global hotkey is pressed.