### PR TITLE
Add Screenshot Browser feature

### DIFF
--- a/UnoraLaunchpad/MainWindow.xaml
+++ b/UnoraLaunchpad/MainWindow.xaml
@@ -117,10 +117,22 @@
         <Grid Grid.Row="0"
               Background="{DynamicResource TitleBarColor}"
               MouseDown="TitleBar_MouseDown">
+            <!-- Screenshots Button -->
+            <Button HorizontalAlignment="Right"
+                    Margin="0, 0, 195, 0" <!-- Adjusted margin for new button -->
+                    Click="ScreenshotsButton_Click"
+                    ToolTip="Open Screenshot Browser"
+                    Background="{DynamicResource ButtonTransparentBackgroundColor}"
+                    Foreground="{DynamicResource IconForegroundColor}"
+                    BorderBrush="{DynamicResource ButtonTransparentBackgroundColor}"
+                    shell:WindowChrome.IsHitTestVisibleInChrome="True">
+                <materialDesign:PackIcon Kind="ImageMultipleOutline" />
+            </Button>
             <!-- Patch Notes Button -->
             <Button HorizontalAlignment="Right"
                     Margin="0, 0, 165, 0"
                     Click="PatchNotesButton_Click"
+                    ToolTip="View Patch Notes"
                     Background="{DynamicResource ButtonTransparentBackgroundColor}"
                     Foreground="{DynamicResource IconForegroundColor}"
                     BorderBrush="{DynamicResource ButtonTransparentBackgroundColor}"
@@ -130,6 +142,7 @@
             <!-- Discord Button -->
             <Button HorizontalAlignment="Right"
                     Margin="0, 0, 135, 0"
+                    ToolTip="Join Discord"
                     Click="DiscordButton_Click"
                     Background="{DynamicResource ButtonTransparentBackgroundColor}"
                     Foreground="{DynamicResource IconForegroundColor}"

--- a/UnoraLaunchpad/MainWindow.xaml.cs
+++ b/UnoraLaunchpad/MainWindow.xaml.cs
@@ -82,6 +82,17 @@ namespace UnoraLaunchpad
             _registeredHotkeys = new Dictionary<int, string>();
         }
 
+        private void ScreenshotsButton_Click(object sender, RoutedEventArgs e)
+        {
+            // Determine the selected game's folder name.
+            // Fallback to "Unora" if not found or if settings are null.
+            var selectedGameFolder = _launcherSettings?.SelectedGame ?? CONSTANTS.UNORA_FOLDER_NAME;
+
+            var screenshotBrowser = new ScreenshotBrowserWindow(selectedGameFolder);
+            screenshotBrowser.Owner = this; // Set the owner for proper dialog behavior
+            screenshotBrowser.Show();
+        }
+
 
         // === Global Hotkey System ===
          protected override void OnSourceInitialized(EventArgs e)

--- a/UnoraLaunchpad/ScreenshotBrowserWindow.xaml
+++ b/UnoraLaunchpad/ScreenshotBrowserWindow.xaml
@@ -1,0 +1,111 @@
+<Window x:Class="UnoraLaunchpad.ScreenshotBrowserWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        mc:Ignorable="d"
+        Title="Screenshot Browser" Height="600" Width="800"
+        WindowStyle="None"
+        ResizeMode="CanResize"
+        WindowStartupLocation="CenterOwner"
+        TextElement.Foreground="{DynamicResource PrimaryTextColor}"
+        Background="{DynamicResource PrimaryBackgroundColor}"
+        BorderBrush="{DynamicResource PrimaryBorderColor}"
+        BorderThickness="2"
+        FontFamily="{materialDesign:MaterialDesignFont}">
+
+    <Grid Background="{DynamicResource PrimaryBackgroundColor}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="30" /> <!-- Custom Title Bar -->
+            <RowDefinition Height="*" /> <!-- Main Content -->
+            <RowDefinition Height="45" /> <!-- Bottom Bar / Controls -->
+        </Grid.RowDefinitions>
+
+        <!-- Custom Title Bar -->
+        <Grid Grid.Row="0" Background="{DynamicResource TitleBarColor}" MouseDown="TitleBar_MouseDown">
+            <Button HorizontalAlignment="Right"
+                    VerticalAlignment="Center"
+                    Click="CloseButton_Click"
+                    Style="{StaticResource TitleBarIconButtonStyle}" ToolTip="Close">
+                <materialDesign:PackIcon Kind="Close" Foreground="{DynamicResource IconForegroundColor}"/>
+            </Button>
+            <Label Content="Screenshot Browser"
+                   Foreground="{DynamicResource TitleBarTextColor}"
+                   HorizontalAlignment="Left"
+                   VerticalAlignment="Center" Margin="10,0,0,0" />
+        </Grid>
+
+        <!-- Main Content -->
+        <Grid Grid.Row="1" Background="{DynamicResource SecondaryBackgroundColor}" Margin="5">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*" MinWidth="200"/> <!-- Thumbnails Area -->
+                <ColumnDefinition Width="Auto" /> <!-- Grid Splitter -->
+                <ColumnDefinition Width="7*" MinWidth="300"/> <!-- Large Preview Area -->
+            </Grid.ColumnDefinitions>
+
+            <!-- Thumbnails Area -->
+            <ScrollViewer Grid.Column="0" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                <ItemsControl x:Name="ThumbnailsItemsControl" Margin="5">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <WrapPanel Orientation="Horizontal" HorizontalAlignment="Center"/>
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border BorderBrush="{DynamicResource PrimaryBorderColor}" BorderThickness="1" Margin="5" Padding="5" Background="{DynamicResource TertiaryBackgroundColor}">
+                                <StackPanel Width="120">
+                                    <Image Source="{Binding Thumbnail}" Height="80" Stretch="Uniform" Margin="0,0,0,5"/>
+                                    <TextBlock Text="{Binding FileName}" TextTrimming="CharacterEllipsis" ToolTip="{Binding FileName}" HorizontalAlignment="Center" FontSize="10" Foreground="{DynamicResource SecondaryTextColor}"/>
+                                    <TextBlock Text="{Binding CreationDate, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" HorizontalAlignment="Center" FontSize="9" Foreground="{DynamicResource SecondaryTextColor}"/>
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                    <!-- Add ItemContainerStyle to make items clickable -->
+                    <ItemsControl.ItemContainerStyle>
+                        <Style TargetType="ContentPresenter">
+                            <EventSetter Event="MouseLeftButtonUp" Handler="Thumbnail_Click"/>
+                            <Setter Property="Cursor" Value="Hand"/>
+                        </Style>
+                    </ItemsControl.ItemContainerStyle>
+                </ItemsControl>
+            </ScrollViewer>
+
+            <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Center" VerticalAlignment="Stretch" Background="{DynamicResource PrimaryBorderColor}"/>
+
+            <!-- Large Preview Area -->
+            <Border Grid.Column="2" Margin="5" BorderBrush="{DynamicResource PrimaryBorderColor}" BorderThickness="1" Background="{DynamicResource TertiaryBackgroundColor}">
+                <Image x:Name="LargePreviewImage" Stretch="Uniform" Margin="5"/>
+            </Border>
+        </Grid>
+
+        <!-- Bottom Bar / Controls -->
+        <Grid Grid.Row="2" Background="{DynamicResource TitleBarColor}">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,0,0,0">
+                <TextBlock Text="Sort by:" VerticalAlignment="Center" Margin="0,0,5,0" Foreground="{DynamicResource PrimaryTextColor}"/>
+                <Button x:Name="SortNewestButton" Content="Newest First" Click="SortNewestButton_Click" Style="{StaticResource BottomBarActionButtonStyle}" Margin="0,0,5,0"/>
+                <Button x:Name="SortOldestButton" Content="Oldest First" Click="SortOldestButton_Click" Style="{StaticResource BottomBarActionButtonStyle}"/>
+            </StackPanel>
+
+            <TextBlock x:Name="StatusTextBlock" VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource SecondaryTextColor}" Margin="5"/>
+
+            <Button x:Name="OpenFolderButton" Click="OpenFolderButton_Click"
+                    Style="{StaticResource BottomBarActionButtonStyle}"
+                    HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,80,0"
+                    ToolTip="Open Screenshots Folder">
+                <materialDesign:PackIcon Kind="FolderOpenOutline" Margin="0,0,5,0"/>
+                <TextBlock Text="Open Folder"/>
+            </Button>
+
+            <Button x:Name="RefreshButton" Click="RefreshButton_Click"
+                    Style="{StaticResource BottomBarActionButtonStyle}"
+                    HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,200,0"
+                    ToolTip="Refresh Screenshots">
+                <materialDesign:PackIcon Kind="Refresh" Margin="0,0,5,0"/>
+                <TextBlock Text="Refresh"/>
+            </Button>
+        </Grid>
+    </Grid>
+</Window>

--- a/UnoraLaunchpad/ScreenshotBrowserWindow.xaml.cs
+++ b/UnoraLaunchpad/ScreenshotBrowserWindow.xaml.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media.Imaging;
+
+namespace UnoraLaunchpad
+{
+    public partial class ScreenshotBrowserWindow : Window
+    {
+        public ObservableCollection<ScreenshotInfo> Screenshots { get; set; }
+        private string _screenshotsFolderPath; // To be configured, e.g., "Unora/screenshots"
+        private string _gameFolderName; // e.g., "Unora"
+
+        // Constructor that accepts the game folder name
+        public ScreenshotBrowserWindow(string gameFolderName = "Unora") // Default to "Unora" for now
+        {
+            InitializeComponent();
+            _gameFolderName = gameFolderName;
+            // It's common for games to save screenshots directly in the main game folder or a subfolder.
+            // Let's assume a "screenshots" subfolder first. If not found, try the game root.
+            string screenshotsSubfolderPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, _gameFolderName, "screenshots");
+            string gameRootPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, _gameFolderName);
+
+            if (Directory.Exists(screenshotsSubfolderPath))
+            {
+                _screenshotsFolderPath = screenshotsSubfolderPath;
+            }
+            else if (Directory.Exists(gameRootPath)) // Fallback to game root if "screenshots" subfolder doesn't exist
+            {
+                _screenshotsFolderPath = gameRootPath;
+            }
+            else
+            {
+                // Neither path exists, disable functionality or show error
+                _screenshotsFolderPath = gameRootPath; // Default to gameRoot for creation attempt
+                StatusTextBlock.Text = $"Screenshots folder not found for '{_gameFolderName}'. Will attempt to use/create default.";
+                // Optionally disable buttons if folder is critical and not found
+            }
+
+            Screenshots = new ObservableCollection<ScreenshotInfo>();
+            ThumbnailsItemsControl.ItemsSource = Screenshots;
+            DataContext = this; // Not strictly necessary here as ItemsSource is set directly
+
+            LoadScreenshots();
+        }
+
+
+        private void LoadScreenshots()
+        {
+            Screenshots.Clear();
+            LargePreviewImage.Source = null; // Clear previous large preview
+
+            if (!Directory.Exists(_screenshotsFolderPath))
+            {
+                StatusTextBlock.Text = $"Screenshots folder '{_screenshotsFolderPath}' not found.";
+                try
+                {
+                    Directory.CreateDirectory(_screenshotsFolderPath);
+                    StatusTextBlock.Text = $"Created screenshots folder: '{_screenshotsFolderPath}'. No screenshots yet.";
+                }
+                catch (Exception ex)
+                {
+                    StatusTextBlock.Text = $"Error creating folder '{_screenshotsFolderPath}': {ex.Message}";
+                    MessageBox.Show($"Could not create screenshots directory: {_screenshotsFolderPath}\n{ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    return;
+                }
+                return;
+            }
+
+            try
+            {
+                var screenshotFiles = Directory.EnumerateFiles(_screenshotsFolderPath, "lod*.bmp")
+                                             .Select(f => new FileInfo(f))
+                                             .ToList();
+
+                if (!screenshotFiles.Any())
+                {
+                    StatusTextBlock.Text = "No screenshots found (lod*.bmp).";
+                    return;
+                }
+
+                foreach (var fileInfo in screenshotFiles.OrderByDescending(f => f.CreationTime)) // Default sort: newest first
+                {
+                    var screenshotInfo = new ScreenshotInfo(fileInfo.FullName, fileInfo.CreationTime);
+
+                    // Create and cache thumbnail
+                    try
+                    {
+                        BitmapImage thumbnail = new BitmapImage();
+                        thumbnail.BeginInit();
+                        thumbnail.UriSource = new Uri(fileInfo.FullName);
+                        thumbnail.DecodePixelWidth = 100; // Create a smaller image for thumbnail
+                        thumbnail.CacheOption = BitmapCacheOption.OnLoad; // Cache it in memory
+                        thumbnail.EndInit();
+                        thumbnail.Freeze(); // Important for performance in collections
+                        screenshotInfo.Thumbnail = thumbnail;
+                        Screenshots.Add(screenshotInfo);
+                    }
+                    catch (Exception ex)
+                    {
+                        // Log or handle error for individual file loading
+                        Debug.WriteLine($"Error loading thumbnail for {fileInfo.FullName}: {ex.Message}");
+                        // Optionally, add a placeholder or skip this screenshot
+                    }
+                }
+                StatusTextBlock.Text = $"Loaded {Screenshots.Count} screenshots.";
+                if (Screenshots.Any())
+                {
+                    // Display the first screenshot's full image by default
+                    DisplayFullImage(Screenshots.First());
+                }
+            }
+            catch (Exception ex)
+            {
+                StatusTextBlock.Text = $"Error loading screenshots: {ex.Message}";
+                MessageBox.Show($"Error accessing screenshots directory: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private void Thumbnail_Click(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is FrameworkElement element && element.DataContext is ScreenshotInfo selectedScreenshot)
+            {
+                DisplayFullImage(selectedScreenshot);
+            }
+        }
+
+        private void DisplayFullImage(ScreenshotInfo screenshotInfo)
+        {
+            if (screenshotInfo == null) return;
+
+            try
+            {
+                BitmapImage fullImage = new BitmapImage();
+                fullImage.BeginInit();
+                fullImage.UriSource = new Uri(screenshotInfo.FilePath);
+                fullImage.CacheOption = BitmapCacheOption.OnLoad; // Load fully
+                fullImage.EndInit();
+                fullImage.Freeze(); // Freeze for performance
+                LargePreviewImage.Source = fullImage;
+                StatusTextBlock.Text = $"Displaying: {screenshotInfo.FileName}";
+            }
+            catch (Exception ex)
+            {
+                LargePreviewImage.Source = null; // Clear if loading failed
+                StatusTextBlock.Text = $"Error loading image {screenshotInfo.FileName}: {ex.Message}";
+                MessageBox.Show($"Could not load image: {screenshotInfo.FilePath}\n{ex.Message}", "Image Load Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private void SortNewestButton_Click(object sender, RoutedEventArgs e)
+        {
+            var sortedScreenshots = new ObservableCollection<ScreenshotInfo>(Screenshots.OrderByDescending(s => s.CreationDate));
+            Screenshots.Clear();
+            foreach (var s in sortedScreenshots) Screenshots.Add(s);
+            StatusTextBlock.Text = "Sorted by newest first.";
+             if (Screenshots.Any()) DisplayFullImage(Screenshots.First());
+        }
+
+        private void SortOldestButton_Click(object sender, RoutedEventArgs e)
+        {
+            var sortedScreenshots = new ObservableCollection<ScreenshotInfo>(Screenshots.OrderBy(s => s.CreationDate));
+            Screenshots.Clear();
+            foreach (var s in sortedScreenshots) Screenshots.Add(s);
+            StatusTextBlock.Text = "Sorted by oldest first.";
+            if (Screenshots.Any()) DisplayFullImage(Screenshots.First());
+        }
+
+        private void RefreshButton_Click(object sender, RoutedEventArgs e)
+        {
+            LoadScreenshots();
+        }
+
+        private void OpenFolderButton_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (Directory.Exists(_screenshotsFolderPath))
+                {
+                    Process.Start(new ProcessStartInfo
+                    {
+                        FileName = _screenshotsFolderPath,
+                        UseShellExecute = true,
+                        Verb = "open"
+                    });
+                }
+                else
+                {
+                    MessageBox.Show($"Screenshots folder not found: {_screenshotsFolderPath}", "Error", MessageBoxButton.OK, MessageBoxImage.Warning);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Could not open folder: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private void TitleBar_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (e.ChangedButton == MouseButton.Left)
+            {
+                DragMove();
+            }
+        }
+
+        private void CloseButton_Click(object sender, RoutedEventArgs e)
+        {
+            this.Close();
+        }
+    }
+}

--- a/UnoraLaunchpad/ScreenshotInfo.cs
+++ b/UnoraLaunchpad/ScreenshotInfo.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Windows.Media.Imaging;
+
+namespace UnoraLaunchpad
+{
+    public class ScreenshotInfo
+    {
+        public string FilePath { get; set; }
+        public BitmapImage Thumbnail { get; set; }
+        // FullImage will be loaded on demand, so we might just store the path
+        // and create the BitmapImage when needed, or store it here if pre-loaded.
+        // For now, let's assume it's loaded from FilePath when selected.
+        // public BitmapImage FullImage { get; set; }
+        public DateTime CreationDate { get; set; }
+        public string FileName => System.IO.Path.GetFileName(FilePath);
+
+        public ScreenshotInfo(string filePath, DateTime creationDate)
+        {
+            FilePath = filePath;
+            CreationDate = creationDate;
+            // Thumbnail will be set after construction, typically during the loading process.
+        }
+    }
+}


### PR DESCRIPTION
- Created ScreenshotInfo class to hold screenshot data.
- Implemented ScreenshotBrowserWindow.xaml for the UI, including thumbnail list, large preview, and sorting/action buttons.
- Implemented ScreenshotBrowserWindow.xaml.cs for the code-behind logic:
    - Loads lod*.bmp files from the game folder (checking 'screenshots' subdirectory first, then game root).
    - Generates thumbnails and displays full-size images on demand.
    - Allows sorting by creation date (newest/oldest first).
    - Includes 'Refresh' and 'Open Folder' functionality.
    - Handles errors for missing folders/files and corrupted images.
- Integrated the Screenshot Browser into MainWindow by adding a button in the title bar.
- Ensured the browser uses the currently selected game's folder.